### PR TITLE
GH38: Target Cake 0.33.0, nuspec icon url

### DIFF
--- a/Source/Cake.Gitter/Cake.Gitter.csproj
+++ b/Source/Cake.Gitter/Cake.Gitter.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.28.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="0.28.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Tools/packages.config
+++ b/Tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.30.0" />
+	<package id="Cake" version="0.32.1" />
 </packages>

--- a/nuspec/nuget/Cake.Gitter.nuspec
+++ b/nuspec/nuget/Cake.Gitter.nuspec
@@ -10,7 +10,7 @@
     <licenseUrl>https://github.com/cake-contrib/Cake.Gitter/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/cake-contrib/Cake.Gitter/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://cdn.rawgit.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</iconUrl>
     <copyright>Copyright (c) Cake Contributions 2016 - Present</copyright>
     <tags>Cake, Script, Build, Gitter</tags>
   </metadata>

--- a/setup.cake
+++ b/setup.cake
@@ -1,4 +1,4 @@
-#load nuget:https://www.myget.org/F/cake-contrib/api/v2?package=Cake.Recipe&prerelease
+#load nuget:?package=Cake.Recipe&version=1.0.0
 
 Environment.SetVariableNames();
 


### PR DESCRIPTION
* Target Cake.Core/Common 0.33.0
* Build using Cake.Recipe 1.0.0 and Cake 0.32.1
* use jsdelivr url for nuspec
* fixes #38