### PR TITLE
(build) Update dependabot configuration to search Source folder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/"
+    directory: "/Source"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
This pull request updates the dependabot configuration to use the `Source` folder when searching project files containing nuget dependencies

/cc @gep13