### PR TITLE
(build) Update codeql build to only run build part of recipe

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - run: ./build.ps1
+    - run: ./build.ps1 --target=DotNetCore-Build
       shell: pwsh
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
This commit changes the logic used in the github
action workflow file to only run the .NET core
build itself.
In the context of doing CodeQL analysis it is
not interesting if anything else works.

This should help with making sure that the codeql workflow won't fail unless
something is wrong.

/cc @gep13
